### PR TITLE
Refactored notebooks/test_utils path in notebooks

### DIFF
--- a/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
@@ -337,7 +337,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "interpret_cpu",
+   "display_name": "Python (interpret_cpu)",
    "language": "python",
    "name": "interpret_cpu"
   },

--- a/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
@@ -50,7 +50,7 @@
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
-    "from interpret_text.classical.classical_text_explainer import ClassicalTextExplainer\n",
+    "from interpret_text.classical import ClassicalTextExplainer\n",
     "\n",
     "from notebooks.test_utils.utils_mnli import load_mnli_pandas_df\n",
     "\n",

--- a/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
@@ -333,20 +333,13 @@
    "source": [
     "ExplanationDashboard(local_explanantion)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "interpret_cpu",
    "language": "python",
-   "name": "python3"
+   "name": "interpret_cpu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_classical_text_explainer.ipynb
@@ -10,6 +10,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,21 +38,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "sys.path.append(\"../..\")\n",
     "import os\n",
-    "from interpret_text.classical.classical_text_explainer import ClassicalTextExplainer\n",
     "\n",
     "# sklearn\n",
     "from sklearn.metrics import precision_recall_fscore_support\n",
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
-    "# nlp recipes\n",
-    "from interpret_text.common.utils_unified import load_pandas_df\n",
+    "from interpret_text.classical.classical_text_explainer import ClassicalTextExplainer\n",
+    "\n",
+    "from notebooks.test_utils.utils_mnli import load_mnli_pandas_df\n",
     "\n",
     "# for testing\n",
     "from scrapbook.api import glue\n",
@@ -79,8 +80,7 @@
    "source": [
     "## 2. Setup\n",
     "\n",
-    "The notebook is built on features made available by [scikit-learn](https://scikit-learn.org/stable/) and [spacy](https://spacy.io/) for easier compatibiltiy with popular tookits.                     \n",
-    "The notebook also relies on the pip installable \"utils_nlp.dataset.multinli\" package from Microsoft's [NLP-recipes](https://github.com/microsoft/nlp-recipes/tree/master/utils_nlp) open source package for dataloading purposes. "
+    "The notebook is built on features made available by [scikit-learn](https://scikit-learn.org/stable/) and [spacy](https://spacy.io/) for easier compatibiltiy with popular tookits."
    ]
   },
   {
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = load_pandas_df(DATA_FOLDER, \"train\")\n",
+    "df = load_mnli_pandas_df(DATA_FOLDER, \"train\")\n",
     "df = df[df[\"gold_label\"] == \"neutral\"]  # get unique sentences\n",
     "\n",
     "# fetch documents and labels from data frame\n",
@@ -333,13 +333,20 @@
    "source": [
     "ExplanationDashboard(local_explanantion)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (interpret_cpu)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "interpret_cpu"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -351,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
+    "sys.path.append(\"../..\")\n",
     "import os\n",
     "import json\n",
     "import pandas as pd\n",
@@ -26,10 +27,12 @@
     "import torch.nn as nn\n",
     "import scrapbook as sb\n",
     "\n",
-    "from interpret_text.common.dataset.utils_sst2 import load_sst2_pandas_df\n",
     "from interpret_text.introspective_rationale.introspective_rationale_explainer import IntrospectiveRationaleExplainer\n",
-    "from interpret_text.common.utils_introspective_rationale import GlovePreprocessor, BertPreprocessor, ModelArguments, load_glove_embeddings\n",
-    "from interpret_text.widget import ExplanationDashboard"
+    "from interpret_text.common.utils_introspective_rationale import GlovePreprocessor, BertPreprocessor, ModelArguments\n",
+    "from interpret_text.widget import ExplanationDashboard\n",
+    "\n",
+    "from notebooks.test_utils.utils_sst2 import load_sst2_pandas_df\n",
+    "from notebooks.test_utils.utils_data_shared import load_glove_embeddings"
    ]
   },
   {
@@ -116,6 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "batch_size = 50\n",
     "train_data = load_sst2_pandas_df('train')\n",
     "test_data = load_sst2_pandas_df('test')\n",
     "all_data = pd.concat([train_data, test_data])\n",

--- a/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb
@@ -266,7 +266,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "interpret_cpu",
+   "display_name": "Python (interpret_cpu)",
    "language": "python",
    "name": "interpret_cpu"
   },

--- a/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_introspective_rationale_explainer.ipynb
@@ -119,11 +119,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "batch_size = 50\n",
     "train_data = load_sst2_pandas_df('train')\n",
     "test_data = load_sst2_pandas_df('test')\n",
     "all_data = pd.concat([train_data, test_data])\n",
     "if QUICK_RUN:\n",
+    "    batch_size = 50\n",
     "    train_data = train_data.head(batch_size)\n",
     "    test_data = test_data.head(batch_size)\n",
     "X_train = train_data[TEXT_COL]\n",
@@ -262,20 +262,13 @@
    "source": [
     "ExplanationDashboard(local_explanation)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "interpret_cpu",
    "language": "python",
-   "name": "python3"
+   "name": "interpret_cpu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/text_classification/text_classification_unified_information_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_unified_information_explainer.ipynb
@@ -51,9 +51,10 @@
     "import torch\n",
     "import torch.nn as nn\n",
     "\n",
-    "from interpret_text.common.utils_unified import load_pandas_df\n",
     "from interpret_text.common.utils_bert import Language, Tokenizer, BERTSequenceClassifier\n",
-    "from interpret_text.common.timer import Timer"
+    "from interpret_text.common.timer import Timer\n",
+    "\n",
+    "from notebooks.test_utils.utils_mnli import load_mnli_pandas_df"
    ]
   },
   {
@@ -132,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = load_pandas_df(DATA_FOLDER, \"train\")\n",
+    "df = load_mnli_pandas_df(DATA_FOLDER, \"train\")\n",
     "df = df[df[\"gold_label\"]==\"neutral\"]  # get unique sentences"
    ]
   },
@@ -433,6 +434,13 @@
    "source": [
     "ExplanationDashboard(explanation_unified)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/text_classification/text_classification_unified_information_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_unified_information_explainer.ipynb
@@ -434,20 +434,13 @@
    "source": [
     "ExplanationDashboard(explanation_unified)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "interpret_cpu",
    "language": "python",
-   "name": "python3"
+   "name": "interpret_cpu"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/text_classification/text_classification_unified_information_explainer.ipynb
+++ b/notebooks/text_classification/text_classification_unified_information_explainer.ipynb
@@ -438,7 +438,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "interpret_cpu",
+   "display_name": "Python (interpret_cpu)",
    "language": "python",
    "name": "interpret_cpu"
   },

--- a/python/interpret_text/classical/__init__.py
+++ b/python/interpret_text/classical/__init__.py
@@ -1,0 +1,1 @@
+from .classical_text_explainer import ClassicalTextExplainer


### PR DESCRIPTION
* The duplicated dataset loader code from nlp_recipes/nlp_utils have been moved under /notebooks/test_urils as a temporary fix till we get the stable pip install version of nlp_recipers/nlp_utils.

* This PR contains refactoring for util path in /notebooks 