### PR TITLE
setup.py : updated widget file paths from `interpret-text/` to `interpret-text/experimental/`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -70,10 +70,10 @@ setup(
         (
             "share/jupyter/nbextensions/interpret-text-widget",
             [
-                "interpret_text/widget/static/extension.js",
-                "interpret_text/widget/static/extension.js.map",
-                "interpret_text/widget/static/index.js",
-                "interpret_text/widget/static/index.js.map",
+                "interpret_text/experimental/widget/static/extension.js",
+                "interpret_text/experimental/widget/static/extension.js.map",
+                "interpret_text/experimental/widget/static/index.js",
+                "interpret_text/experimental/widget/static/index.js.map",
             ],
         ),
         (
@@ -83,7 +83,7 @@ setup(
         (
             "share/jupyter/lab/extensions",
             [
-                "interpret_text/widget/js/"
+                "interpret_text/experimental/widget/js/"
                 "interpret_text_widget/labextension/interpret-text-widget-0.1.7.tgz"
             ],
         ),


### PR DESCRIPTION
related issue: https://github.com/interpretml/interpret-text-contrib/issues/91